### PR TITLE
add domain and attach to network

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ welcome:
 help: welcome
 	@grep -E '^[0-9a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | grep ^help -v | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-22s\033[0m %s\n", $$1, $$2}'
 
-build: welcome  ## Builds DNR image
+build: welcome  ## Build DNR image
 	@if [ -z '${HAS_IMAGE}' ]; \
 		then \
 			docker build \
@@ -76,12 +76,12 @@ test: welcome build ## Run tests
 			${APP_NAME} \
 			pytest
 
-rmi: ## Remove docker image
+rmi: ## Remove DNR image
 	@if [ '${HAS_IMAGE}' ]; \
 		then \
 			docker rmi ${APP_NAME} \
 		; \
 	fi
 
-stop: ## Stop container
+stop: ## Stop DNR
 	@docker stop ${APP_NAME}

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ fe00::0 ip6-localnet
 ff00::0 ip6-mcastprefix
 ff02::1 ip6-allnodes
 ff02::2	ip6-allrouters
-172.17.0.2	my_service #DNR
+172.17.0.2	my_service.dnr
 ```
 
 Now it's possible to ping container name and host will be able to resolve it.

--- a/host.py
+++ b/host.py
@@ -33,17 +33,19 @@ def insert_on_hosts(ip: str, name: str, paths: list):
         with open(path) as original_hosts:
             content = original_hosts.read()
 
-        if name not in content:
-            if content and content[-1] in string.ascii_letters:
-                content += '\n'
+        if name in content:
+            continue
 
-            parent = pathlib.Path(path).parent
-            with tempfile.NamedTemporaryFile(dir=parent) as new_hosts:
-                temp = f'{content}{hosts_entry}'
-                b = bytes(temp, 'utf-8')
-                new_hosts.write(b)
-                new_hosts.seek(0)
-                shutil.copy(parent.joinpath(new_hosts.name), path)
+        if content and content[-1] in string.ascii_letters:
+            content += '\n'
+
+        parent = pathlib.Path(path).parent
+        with tempfile.NamedTemporaryFile(dir=parent) as new_hosts:
+            temp = f'{content}{hosts_entry}'
+            b = bytes(temp, 'utf-8')
+            new_hosts.write(b)
+            new_hosts.seek(0)
+            shutil.copy(parent.joinpath(new_hosts.name), path)
 
 
 def remove_from_hosts(pattern: re.Pattern, paths: list):

--- a/host.py
+++ b/host.py
@@ -24,11 +24,11 @@ def get_hosts_paths(system: str, release: str) -> list:
 
 
 def build_hosts_pattern(name):
-    return re.compile(r'^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}[ \t]*' + name + r'[ \t]*#DNR.*$')
+    return re.compile(r'^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}[ \t]*' + name + r'\.dnr.*$')
 
 
 def initial_update_hosts(network_info: dict, paths: list):
-    pattern = re.compile(r'^.*#DNR.*$')
+    pattern = re.compile(r'^.*\.dnr.*$')
     remove_from_hosts(pattern, paths)
 
     for container_info in network_info.get('Containers').values():
@@ -38,7 +38,7 @@ def initial_update_hosts(network_info: dict, paths: list):
 
 
 def insert_on_hosts(ip: str, name: str, paths: list):
-    hosts_entry = f'{ip}\t{name} #DNR\n'
+    hosts_entry = f'{ip}\t{name}.dnr\n'
     for path in paths:
         with open(path) as original_hosts:
             content = original_hosts.read()

--- a/host.py
+++ b/host.py
@@ -27,16 +27,6 @@ def build_hosts_pattern(name):
     return re.compile(r'^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}[ \t]*' + name + r'\.dnr.*$')
 
 
-def initial_update_hosts(network_info: dict, paths: list):
-    pattern = re.compile(r'^.*\.dnr.*$')
-    remove_from_hosts(pattern, paths)
-
-    for container_info in network_info.get('Containers').values():
-        container_ip = container_info.get('IPv4Address').split('/')[0]
-        container_name = container_info.get('Name')
-        insert_on_hosts(container_ip, container_name, paths)
-
-
 def insert_on_hosts(ip: str, name: str, paths: list):
     hosts_entry = f'{ip}\t{name}.dnr\n'
     for path in paths:

--- a/main.py
+++ b/main.py
@@ -1,23 +1,42 @@
 #!/usr/bin/python3
 import platform
+import re
 
 import docker
+from docker.errors import APIError
 
 from event import is_start, is_die, get_container_name, get_container_ip
-from host import initial_update_hosts, build_hosts_pattern, get_hosts_paths, insert_on_hosts, remove_from_hosts
+from host import build_hosts_pattern, get_hosts_paths, insert_on_hosts, remove_from_hosts
 
 if __name__ == '__main__':
     client = docker.from_env()
     system = platform.uname().system.lower()
     release = platform.uname().release.lower()
     hosts_path = get_hosts_paths(system, release)
-    network = client.api.inspect_network('bridge')
+    network_bridge = client.api.inspect_network('bridge')
+    dnr_network_name = 'dnr-network'
 
-    initial_update_hosts(network, hosts_path)
+    try:
+        client.api.create_network(dnr_network_name, check_duplicate=True)
+    except APIError:
+        pass  # Network already exists
+
+    pattern = re.compile(r'^.*\.dnr.*$')
+    remove_from_hosts(pattern, hosts_path)
+    for container_info in network_bridge.get('Containers').values():
+        container_ip = container_info.get('IPv4Address').split('/')[0]
+        container_name = container_info.get('Name')
+        try:
+            client.api.connect_container_to_network(container_name, dnr_network_name)
+        except APIError:
+            pass  # Container already attached to network
+
+        insert_on_hosts(container_ip, container_name, hosts_path)
+
     for event in client.events(decode=True):
         if is_start(event):
-            network = client.api.inspect_network('bridge')
-            container_ip = get_container_ip(event, network)
+            network_bridge = client.api.inspect_network('bridge')
+            container_ip = get_container_ip(event, network_bridge)
             container_name = get_container_name(event)
             insert_on_hosts(container_ip, container_name, hosts_path)
 

--- a/main.py
+++ b/main.py
@@ -26,12 +26,11 @@ if __name__ == '__main__':
     for container_info in network_bridge.get('Containers').values():
         container_ip = container_info.get('IPv4Address').split('/')[0]
         container_name = container_info.get('Name')
+        insert_on_hosts(container_ip, container_name, hosts_path)
         try:
             client.api.connect_container_to_network(container_name, dnr_network_name)
         except APIError:
-            pass  # Container already attached to network
-
-        insert_on_hosts(container_ip, container_name, hosts_path)
+            pass
 
     for event in client.events(decode=True):
         if is_start(event):

--- a/test_host.py
+++ b/test_host.py
@@ -120,6 +120,22 @@ ff02::2 ip6-allrouters
         for c in contents:
             assert c == expected_result
 
+    def test_insert_on_hosts_duplicated(self):
+        contents = []
+        fake_ip = '123.123.123.123'
+        fake_name = 'fake_name'
+        self._create_fake_file(self.fake_initial_content_3)
+        insert_on_hosts(fake_ip, fake_name, self.paths)
+        for p in self.paths:
+            with open(p) as file:
+                contents.append(file.read())
+
+        self._delete_fake_file()
+        hosts_entry = f'{fake_ip}\t{fake_name}.dnr\n'
+        expected_result = self.fake_initial_content_3
+        for c in contents:
+            assert c == expected_result
+
     def test_remove_from_hosts_3(self):
         contents = []
         pattern = build_hosts_pattern('fake_name')

--- a/test_host.py
+++ b/test_host.py
@@ -28,7 +28,7 @@ fe00::0 ip6-localnet
 ff00::0 ip6-mcastprefix
 ff02::1 ip6-allnodes
 ff02::2 ip6-allrouters
-123.123.123.123 fake_name #DNR
+123.123.123.123 fake_name.dnr
 '''
     fake_initial_content_4 = '''
 127.0.0.1	localhost
@@ -40,8 +40,8 @@ fe00::0 ip6-localnet
 ff00::0 ip6-mcastprefix
 ff02::1 ip6-allnodes
 ff02::2 ip6-allrouters
-123.123.123.123 fake_name2 #DNR
-123.123.123.123 fake_name #DNR
+123.123.123.123 fake_name2.dnr
+123.123.123.123 fake_name.dnr
 '''
 
     def _create_fake_file(self, content: str):
@@ -79,13 +79,13 @@ ff02::2 ip6-allrouters
 
     @staticmethod
     def test_build_hosts_pattern():
-        expected_result = re.compile(r'^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}[ \t]*fake_name[ \t]*#DNR.*$')
+        expected_result = re.compile(r'^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}[ \t]*fake_name\.dnr.*$')
         pattern = build_hosts_pattern('fake_name')
         assert pattern == expected_result
 
     @staticmethod
     def test_build_hosts_pattern_match():
-        fake_string = '123.123.123.123  fake_name   #DNR'
+        fake_string = '123.123.123.123  fake_name.dnr'
         pattern = build_hosts_pattern('fake_name')
         assert re.match(pattern, fake_string) is not None
 
@@ -100,9 +100,9 @@ ff02::2 ip6-allrouters
                 contents.append(file.read())
 
         self._delete_fake_file()
-        hosts_entry = f'{fake_ip}\t{fake_name} #DNR\n'
+        expected_result = f'{fake_ip}\t{fake_name}.dnr\n'
         for c in contents:
-            assert c == hosts_entry
+            assert c == expected_result
 
     def test_insert_on_hosts_2(self):
         contents = []
@@ -115,13 +115,14 @@ ff02::2 ip6-allrouters
                 contents.append(file.read())
 
         self._delete_fake_file()
-        hosts_entry = f'{fake_ip}\t{fake_name} #DNR\n'
+        hosts_entry = f'{fake_ip}\t{fake_name}.dnr\n'
+        expected_result = self.fake_initial_content_2 + hosts_entry
         for c in contents:
-            assert c == self.fake_initial_content_2 + hosts_entry
+            assert c == expected_result
 
     def test_initial_update_hosts_insert(self):
         contents = []
-        expected_content = '123.123.123.123\tContainer 1 #DNR\n321.321.321.321\tContainer 2 #DNR\n'
+        expected_content = '123.123.123.123\tContainer 1.dnr\n321.321.321.321\tContainer 2.dnr\n'
         fake_network = {
             'Containers': {
                 '1': {'Name': 'Container 1', 'IPv4Address': '123.123.123.123/16'},
@@ -199,7 +200,7 @@ fe00::0 ip6-localnet
 ff00::0 ip6-mcastprefix
 ff02::1 ip6-allnodes
 ff02::2 ip6-allrouters
-123.123.123.123 fake_name #DNR
+123.123.123.123 fake_name.dnr
 '''
         self._create_fake_file(self.fake_initial_content_4)
         remove_from_hosts(pattern, self.paths)

--- a/test_host.py
+++ b/test_host.py
@@ -1,7 +1,7 @@
 import os
 import re
 
-from host import initial_update_hosts, build_hosts_pattern, get_hosts_paths, insert_on_hosts, remove_from_hosts
+from host import build_hosts_pattern, get_hosts_paths, insert_on_hosts, remove_from_hosts
 
 
 class TestHost:
@@ -119,49 +119,6 @@ ff02::2 ip6-allrouters
         expected_result = self.fake_initial_content_2 + hosts_entry
         for c in contents:
             assert c == expected_result
-
-    def test_initial_update_hosts_insert(self):
-        contents = []
-        expected_content = '123.123.123.123\tContainer 1.dnr\n321.321.321.321\tContainer 2.dnr\n'
-        fake_network = {
-            'Containers': {
-                '1': {'Name': 'Container 1', 'IPv4Address': '123.123.123.123/16'},
-                '2': {'Name': 'Container 2', 'IPv4Address': '321.321.321.321/16'},
-            }
-        }
-        self._create_fake_file(self.fake_initial_content_1)
-        initial_update_hosts(fake_network, self.paths)
-        for p in self.paths:
-            with open(p) as file:
-                contents.append(file.read())
-
-        self._delete_fake_file()
-        for c in contents:
-            assert c == expected_content
-
-    def test_initial_update_hosts_remove(self):
-        contents = []
-        expected_content = '''
-127.0.0.1	localhost
-127.0.1.1	HUNB707
-
-# The following lines are desirable for IPv6 capable hosts
-::1     ip6-localhost ip6-loopback
-fe00::0 ip6-localnet
-ff00::0 ip6-mcastprefix
-ff02::1 ip6-allnodes
-ff02::2 ip6-allrouters
-'''
-        fake_network = {'Containers': {}}
-        self._create_fake_file(self.fake_initial_content_4)
-        initial_update_hosts(fake_network, self.paths)
-        for p in self.paths:
-            with open(p) as file:
-                contents.append(file.read())
-
-        self._delete_fake_file()
-        for c in contents:
-            assert c == expected_content
 
     def test_remove_from_hosts_3(self):
         contents = []


### PR DESCRIPTION
# Add dnr domain and attach to dnr-network

- Containers were not able to resolve each other names. To do so it's necessary to create a custom network and attach them to it.
- Instead of adding a comment at line end, created a custom domain `.dnr` appended to container name.