### PR TITLE
ci: OCI attestations and bump Docker/GitHub actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,13 +10,13 @@ jobs:
     environment: production
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -31,17 +31,18 @@ jobs:
 
       - name: Extract Docker metadata
         id: docker_meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ secrets.DOCKER_USERNAME }}/docker-name-resolver
 
       - name: Build and push image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           target: release
           platforms: linux/amd64
           push: true
+          outputs: type=registry,oci-mediatypes=true,oci-artifact=true
           tags: |
             ${{ secrets.DOCKER_USERNAME }}/docker-name-resolver:latest
             ${{ secrets.DOCKER_USERNAME }}/docker-name-resolver:${{ steps.meta.outputs.VERSION }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,12 @@ jobs:
           VERSION="${TAG#v}"
           echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
 
+      - name: Extract Docker metadata
+        id: docker_meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ secrets.DOCKER_USERNAME }}/docker-name-resolver
+
       - name: Build and push image
         uses: docker/build-push-action@v5
         with:
@@ -39,6 +45,8 @@ jobs:
           tags: |
             ${{ secrets.DOCKER_USERNAME }}/docker-name-resolver:latest
             ${{ secrets.DOCKER_USERNAME }}/docker-name-resolver:${{ steps.meta.outputs.VERSION }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
+          annotations: ${{ steps.docker_meta.outputs.annotations }}
           sbom: true
           provenance: mode=max
 


### PR DESCRIPTION
## Summary

- Configure `docker/build-push-action` with `outputs: type=registry,oci-mediatypes=true,oci-artifact=true` so SBOM and provenance are exported in OCI-friendly form for Docker Hub / Docker Scout ([Build attestations](https://docs.docker.com/build/metadata/attestations/)).
- Bump actions: `actions/checkout@v5`, `docker/setup-buildx-action@v4`, `docker/login-action@v4`, `docker/metadata-action@v6`, `docker/build-push-action@v7`.

## Notes

After merge, publish a new release to rebuild the image; existing digests will not gain attestations retroactively.