### PR TITLE
fix: Docker Scout supply chain attestations

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,6 @@ jobs:
           target: release
           platforms: linux/amd64
           push: true
-          outputs: type=registry,oci-mediatypes=true,oci-artifact=true
           tags: |
             ${{ secrets.DOCKER_USERNAME }}/docker-name-resolver:latest
             ${{ secrets.DOCKER_USERNAME }}/docker-name-resolver:${{ steps.meta.outputs.VERSION }}


### PR DESCRIPTION
## Summary

Removes the `outputs: type=registry,oci-mediatypes=true,oci-artifact=true` line from the publish workflow so SBOM and provenance (mode=max) attach in the format Docker Scout expects for the [Supply Chain Attestations](https://docs.docker.com/scout/policy/#supply-chain-attestations) policy.

## Changes

- `.github/workflows/publish.yml`: rely on `push: true` only; keep `sbom: true` and `provenance: mode=max`.

## Context

OCI artifact-style outputs can publish attestations in a way policy evaluation does not read correctly on Docker Hub; default registry push aligns with the documented `docker build-push-action` setup for attestations.