### PR TITLE
fix: remove manifest annotations for Docker Scout attestations

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,7 +46,6 @@ jobs:
             ${{ secrets.DOCKER_USERNAME }}/docker-name-resolver:latest
             ${{ secrets.DOCKER_USERNAME }}/docker-name-resolver:${{ steps.meta.outputs.VERSION }}
           labels: ${{ steps.docker_meta.outputs.labels }}
-          annotations: ${{ steps.docker_meta.outputs.annotations }}
           sbom: true
           provenance: mode=max
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,6 @@ jobs:
           target: release
           platforms: linux/amd64
           push: true
-          outputs: type=registry,oci-mediatypes=true,oci-artifact=true
           tags: |
             ${{ secrets.DOCKER_USERNAME }}/docker-name-resolver:latest
             ${{ secrets.DOCKER_USERNAME }}/docker-name-resolver:${{ steps.meta.outputs.VERSION }}

--- a/README.md
+++ b/README.md
@@ -46,39 +46,39 @@ without changing the host's `hosts` file or requiring a custom DNS server.
 ## Architecture
 
 ```mermaid
-graph TD
-    UserBrowser([Browser / Curl <br> http://db.localhost]) --> ResolveLocalhost
-    UserCLI([Host Terminal <br> docker exec dnr list]) -.-> DNR_CLI
+flowchart TD
+    UserBrowser([Browser or curl to db.localhost]) --> ResolveLocalhost
+    UserCLI([Host terminal docker exec dnr list]) -.-> DNR_CLI
 
-    subgraph Host_OS["Host OS: Linux, Mac, Windows"]
-        ResolveLocalhost[OS resolves .localhost <br> to 127.0.0.1] --> PortMap[Docker port mapping <br> Port 80]
+    subgraph HostOS
+        ResolveLocalhost[OS resolves dot-localhost to 127.0.0.1] --> PortMap[Docker publishes port 80]
     end
 
     PortMap --> NginxProxy
-    
-    subgraph Container_DNR["DNR container"]
-        NginxProxy[Nginx Reverse Proxy]
-        StatusPage[index.html status page <br> at http://dnr.localhost/]
+
+    subgraph DNRContainer
+        NginxProxy[Nginx reverse proxy]
+        StatusPage[Status page at dnr.localhost]
         NginxProxy -.-> StatusPage
 
-        subgraph Python_Process["Python process, PID 1"]
+        subgraph PythonProc
             DNR_Daemon[Event daemon]
-            TruthSource[get_active_containers()]
-            NginxManager[nginx.py <br> Generates .conf and .html]
-            DNR_CLI[Comando CLI: list]
+            TruthSource[get_active_containers]
+            NginxManager[nginx.py generates conf and html]
+            DNR_CLI[CLI list command]
         end
 
-        DNR_Daemon -.->|Reads start/die events| TruthSource
-        TruthSource -.->|Network data| NginxManager
-        NginxManager -.->|Generates configs| NginxProxy
-        NginxManager -.->|Generates status page| StatusPage
-        DNR_CLI -.->|Queries| TruthSource
+        DNR_Daemon -.->|start or die events| TruthSource
+        TruthSource -.->|network data| NginxManager
+        NginxManager -.->|writes configs| NginxProxy
+        NginxManager -.->|writes status page| StatusPage
+        DNR_CLI -.->|queries| TruthSource
     end
 
-    DNR_Daemon <==>|socket| DockerSock([/var/run/docker.sock])
+    DNR_Daemon <==>|socket| DockerSock([docker.sock on host])
     TruthSource <==>|inspects networks| DockerSock
-    
-    NginxProxy -->|proxy_pass| TargetIP([Target Container <br> ex: db IP 172.18.0.2])
+
+    NginxProxy -->|proxy_pass| TargetIP([Target container IP])
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -50,18 +50,18 @@ graph TD
     UserBrowser([Browser / Curl <br> http://db.localhost]) --> ResolveLocalhost
     UserCLI([Host Terminal <br> docker exec dnr list]) -.-> DNR_CLI
 
-    subgraph Host_OS [Host OS (Linux, Mac, Windows)]
+    subgraph Host_OS["Host OS: Linux, Mac, Windows"]
         ResolveLocalhost[OS resolves .localhost <br> to 127.0.0.1] --> PortMap[Docker port mapping <br> Port 80]
     end
 
     PortMap --> NginxProxy
     
-    subgraph Container_DNR [DNR Container]
+    subgraph Container_DNR["DNR container"]
         NginxProxy[Nginx Reverse Proxy]
         StatusPage[index.html status page <br> at http://dnr.localhost/]
         NginxProxy -.-> StatusPage
 
-        subgraph Python_Process [Python Process (PID 1)]
+        subgraph Python_Process["Python process, PID 1"]
             DNR_Daemon[Event daemon]
             TruthSource[get_active_containers()]
             NginxManager[nginx.py <br> Generates .conf and .html]

--- a/README.md
+++ b/README.md
@@ -57,9 +57,11 @@ flowchart TD
     PortMap --> NginxProxy
 
     subgraph DNRContainer
-        NginxProxy[Nginx reverse proxy]
-        StatusPage[Status page at dnr.localhost]
-        NginxProxy -.-> StatusPage
+        subgraph NginxProc
+            NginxProxy[Nginx reverse proxy]
+            StatusPage[Status page at dnr.localhost]
+            NginxProxy -.-> StatusPage
+        end
 
         subgraph PythonProc
             DNR_Daemon[Event daemon]


### PR DESCRIPTION
## Summary

Removes `annotations: ${{ steps.docker_meta.outputs.annotations }}` from the publish workflow so BuildKit does not force OCI manifest annotations (which can prevent Docker Scout from seeing [Supply Chain Attestations](https://docs.docker.com/scout/policy/#supply-chain-attestations): SBOM + provenance `mode=max`).

## Changes

- `.github/workflows/publish.yml`: keep `labels` from metadata-action; keep `sbom: true` and `provenance: mode=max`.

## Follow-up

After merge, cut a release so the workflow rebuilds and pushes; then refresh Scout policy evaluation.